### PR TITLE
remove .circleci from R build env entirely

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,7 +9,7 @@
 ^_pkgdown\.yml$
 ^codecov\.yml$
 ^pkgdown.*$
-^\.circleci/config\.yml$
+^\.circleci$
 ^LICENSE.md
 ^CONTRIBUTING.md
 ^CRAN-RELEASE$


### PR DESCRIPTION
Just installed from `remotes`:

```
remotes::install_github('DominikRafacz/deepdep')
Downloading GitHub repo DominikRafacz/deepdep@master
✓  checking for file ‘/private/var/folders/mh/7nlccyqs0rz2pc48c956759m0000gn/T/RtmpHj9NlY/remotes55754a170eee/DominikRafacz-deepdep-dc2a25e/DESCRIPTION’ (436ms)
─  preparing ‘deepdep’:
✓  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
   Removed empty directory ‘deepdep/.circleci’
```

My guess is this would cause failure on `--as-cran` check as well