### PR TITLE
Allow tests to run when vcr is not installed

### DIFF
--- a/R/deepdep.R
+++ b/R/deepdep.R
@@ -10,8 +10,11 @@
 #' @param bioc A \code{logical} value. If \code{TRUE} the Bioconductor dependencies data will be taken from the
 #' Bioconductor repository. For this option to work properly, \code{BiocManager} package needs to be installed.
 #' @param local A \code{logical} value. If \code{TRUE} only data of locally installed packages will be used (without API usage).
-#' @param dependency_type A \code{character} vector. Types of the dependencies that should be sought.
-#' Possibilities are: \code{"Imports", "Depends", "Suggests", "Enhances", "LinkingTo"}. By default it's \code{"Depends", "Imports"}.
+#' @param dependency_type A \code{character} vector. Types of the dependencies that should be sought, a subset of
+#' \code{c("Imports", "Depends", "LinkingTo", "Suggests", "Enhances")}. Other possibilities are: character string
+#' \code{"all"}, a shorthand for the whole vector; character string \code{"most"} for the same vector without \code{"Enhances"};
+#' character string \code{"strong"} (default) for the first three elements of that vector. Works analogously to
+#' \code{\link[tools]{package_dependencies}}.
 #'
 #' @return An object of \code{deepdep} class.
 #'
@@ -35,7 +38,7 @@
 #'
 #' @export
 deepdep <- function(package, depth = 1, downloads = FALSE, bioc = FALSE, local = FALSE,
-                    dependency_type = c("Depends", "Imports")) {
+                    dependency_type = "strong") {
 
   check_package_name(package, bioc, local)
 

--- a/man/deepdep.Rd
+++ b/man/deepdep.Rd
@@ -10,7 +10,7 @@ deepdep(
   downloads = FALSE,
   bioc = FALSE,
   local = FALSE,
-  dependency_type = c("Depends", "Imports")
+  dependency_type = "strong"
 )
 }
 \arguments{
@@ -26,8 +26,11 @@ Bioconductor repository. For this option to work properly, \code{BiocManager} pa
 
 \item{local}{A \code{logical} value. If \code{TRUE} only data of locally installed packages will be used (without API usage).}
 
-\item{dependency_type}{A \code{character} vector. Types of the dependencies that should be sought.
-Possibilities are: \code{"Imports", "Depends", "Suggests", "Enhances", "LinkingTo"}. By default it's \code{"Depends", "Imports"}.}
+\item{dependency_type}{A \code{character} vector. Types of the dependencies that should be sought, a subset of
+\code{c("Imports", "Depends", "LinkingTo", "Suggests", "Enhances")}. Other possibilities are: character string
+\code{"all"}, a shorthand for the whole vector; character string \code{"most"} for the same vector without \code{"Enhances"};
+character string \code{"strong"} (default) for the first three elements of that vector. Works analogously to
+\code{\link[tools]{package_dependencies}}.}
 }
 \value{
 An object of \code{deepdep} class.

--- a/tests/testthat/setup-deepdep.R
+++ b/tests/testthat/setup-deepdep.R
@@ -1,6 +1,8 @@
-library("vcr") # *Required* as vcr is set up on loading
-invisible(vcr::vcr_configure(
-  dir = vcr::vcr_test_path("fixtures"),
-  verbose_errors = TRUE
-))
-vcr::check_cassette_names()
+if (requireNamespace("vcr", quietly=TRUE)) {
+  library("vcr") # *Required* as vcr is set up on loading
+  invisible(vcr::vcr_configure(
+    dir = vcr::vcr_test_path("fixtures"),
+    verbose_errors = TRUE
+  ))
+  vcr::check_cassette_names()
+}

--- a/tests/testthat/setup-deepdep.R
+++ b/tests/testthat/setup-deepdep.R
@@ -1,4 +1,4 @@
-if (requireNamespace("vcr", quietly=TRUE)) {
+if (requireNamespace("vcr", quietly = TRUE)) {
   library("vcr") # *Required* as vcr is set up on loading
   invisible(vcr::vcr_configure(
     dir = vcr::vcr_test_path("fixtures"),

--- a/tests/testthat/test-deepdep.R
+++ b/tests/testthat/test-deepdep.R
@@ -22,19 +22,18 @@ test_that("using shorthand parameters returns the same result", {
   expect_identical(dd, dd2)
 })
 
-if (requireNamespace("vcr", quietly=TRUE)) {
+test_that("obtaining Bioc dependencies returns objects of correct types", {
+  skip_if_not_installed("vcr")
+  
   reset_cached_files("ava")
   reset_cached_files("deps")
   reset_cached_files("desc")
-
+  
   vcr::use_cassette("deepdep-1", {
-    test_that("obtaining Bioc dependencies returns objects of correct types", {
-      dd <- deepdep_wrapped("les", downloads = FALSE, bioc = TRUE, depth = 1, dependency_type = c("Depends", "Imports", "Enhances", "LinkingTo"))
-      expect_is(dd, "deepdep")
-    })
+    dd <- deepdep_wrapped("les", downloads = FALSE, bioc = TRUE, depth = 1, dependency_type = c("Depends", "Imports", "Enhances", "LinkingTo"))
+    expect_is(dd, "deepdep")
   })
-}
-
+})
 
 test_that("incorrect combination of parameters results in error",{
   expect_error(deepdep_wrapped("ggforce", downloads = TRUE, local =  FALSE, bioc = TRUE, depth = 2, dependency_type = c("Depends", "Imports")))
@@ -43,15 +42,15 @@ test_that("incorrect combination of parameters results in error",{
   expect_error(deepdep("ggforce", downloads = TRUE, local =  TRUE, bioc = FALSE, depth = 2, dependency_type = c("Depends", "Imports")))
 })
 
-if (requireNamespace("vcr", quietly=TRUE)) {
+test_that("packages with no dependencies return empty deepdep object in result", {
+  skip_if_not_installed("vcr")
+  
   reset_cached_files("ava")
   reset_cached_files("deps")
   reset_cached_files("desc")
-
+  
   vcr::use_cassette("deepdep-2", {
-    test_that("packages with no dependencies return empty deepdep object in result", {
-      dd <- deepdep("rlang")
-      expect_equal(nrow(dd), 0)
-    })
+    dd <- deepdep("rlang")
+    expect_equal(nrow(dd), 0)
   })
-}
+})

--- a/tests/testthat/test-deepdep.R
+++ b/tests/testthat/test-deepdep.R
@@ -22,16 +22,18 @@ test_that("using shorthand parameters returns the same result", {
   expect_identical(dd, dd2)
 })
 
-reset_cached_files("ava")
-reset_cached_files("deps")
-reset_cached_files("desc")
+if (requireNamespace("vcr", quietly=TRUE)) {
+  reset_cached_files("ava")
+  reset_cached_files("deps")
+  reset_cached_files("desc")
 
-vcr::use_cassette("deepdep-1", {
-  test_that("obtaining Bioc dependencies returns objects of correct types", {
-    dd <- deepdep_wrapped("les", downloads = FALSE, bioc = TRUE, depth = 1, dependency_type = c("Depends", "Imports", "Enhances", "LinkingTo"))
-    expect_is(dd, "deepdep")
+  vcr::use_cassette("deepdep-1", {
+    test_that("obtaining Bioc dependencies returns objects of correct types", {
+      dd <- deepdep_wrapped("les", downloads = FALSE, bioc = TRUE, depth = 1, dependency_type = c("Depends", "Imports", "Enhances", "LinkingTo"))
+      expect_is(dd, "deepdep")
+    })
   })
-})
+}
 
 
 test_that("incorrect combination of parameters results in error",{
@@ -41,13 +43,15 @@ test_that("incorrect combination of parameters results in error",{
   expect_error(deepdep("ggforce", downloads = TRUE, local =  TRUE, bioc = FALSE, depth = 2, dependency_type = c("Depends", "Imports")))
 })
 
-reset_cached_files("ava")
-reset_cached_files("deps")
-reset_cached_files("desc")
+if (requireNamespace("vcr", quietly=TRUE)) {
+  reset_cached_files("ava")
+  reset_cached_files("deps")
+  reset_cached_files("desc")
 
-vcr::use_cassette("deepdep-2", {
-  test_that("packages with no dependencies return empty deepdep object in result", {
-    dd <- deepdep("rlang")
-    expect_equal(nrow(dd), 0)
+  vcr::use_cassette("deepdep-2", {
+    test_that("packages with no dependencies return empty deepdep object in result", {
+      dd <- deepdep("rlang")
+      expect_equal(nrow(dd), 0)
+    })
   })
-})
+}

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,44 +1,43 @@
-if (requireNamespace("vcr", quietly=TRUE)) {
+test_that("dependencies plot has correct layers and objects", {
+  skip_if_not_installed("vcr")
+  
   reset_cached_files("ava")
   reset_cached_files("deps")
   reset_cached_files("desc")
-
+  
   vcr::use_cassette("plot-1", {
     deps <- deepdep("shiny", depth = 2)
   })
-
-
-  test_that("dependencies plot has correct layers and objects", {
-    plt <- plot_dependencies(deps)
-    expect_length(plt$layers, 4)
-    expect_s3_class(plt$layers[[1]]$geom, "GeomPath")
-    expect_s3_class(plt$layers[[1]]$stat, "StatIdentity")
-    expect_s3_class(plt$layers[[2]]$geom, "GeomEdgePath")
-    expect_s3_class(plt$layers[[2]]$stat, "StatEdgeLink")
-    expect_s3_class(plt$layers[[3]]$geom, "GeomPoint")
-    expect_s3_class(plt$layers[[3]]$stat, "StatFilter")
-    expect_s3_class(plt$layers[[4]]$geom, "GeomLabel")
-    expect_s3_class(plt$layers[[4]]$stat, "StatFilter")
-  })
-}
+  
+  plt <- plot_dependencies(deps)
+  expect_length(plt$layers, 4)
+  expect_s3_class(plt$layers[[1]]$geom, "GeomPath")
+  expect_s3_class(plt$layers[[1]]$stat, "StatIdentity")
+  expect_s3_class(plt$layers[[2]]$geom, "GeomEdgePath")
+  expect_s3_class(plt$layers[[2]]$stat, "StatEdgeLink")
+  expect_s3_class(plt$layers[[3]]$geom, "GeomPoint")
+  expect_s3_class(plt$layers[[3]]$stat, "StatFilter")
+  expect_s3_class(plt$layers[[4]]$geom, "GeomLabel")
+  expect_s3_class(plt$layers[[4]]$stat, "StatFilter")
+})
 
 test_that("incorrect object type results in an error", {
   expect_error(plot_dependencies("Wrong type"))
 })
 
-if (requireNamespace("vcr", quietly=TRUE)) {
+test_that("plotting deepdep object with no rows results in less layers", {
+  skip_if_not_installed("vcr")
+  
   reset_cached_files("ava")
   reset_cached_files("deps")
   reset_cached_files("desc")
-
+  
   vcr::use_cassette("plot-2", {
-    test_that("plotting deepdep object with no rows results in less layers", {
-      plt <- plot_dependencies("rlang")
-      expect_s3_class(plt$layers[[1]]$geom, "GeomPoint")
-      expect_s3_class(plt$layers[[1]]$stat, "StatFilter")
-      expect_s3_class(plt$layers[[2]]$geom, "GeomLabel")
-      expect_s3_class(plt$layers[[2]]$stat, "StatFilter")
-
-    })
+    plt <- plot_dependencies("rlang")
   })
-}
+  
+  expect_s3_class(plt$layers[[1]]$geom, "GeomPoint")
+  expect_s3_class(plt$layers[[1]]$stat, "StatFilter")
+  expect_s3_class(plt$layers[[2]]$geom, "GeomLabel")
+  expect_s3_class(plt$layers[[2]]$stat, "StatFilter")
+})

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -1,39 +1,44 @@
-reset_cached_files("ava")
-reset_cached_files("deps")
-reset_cached_files("desc")
+if (requireNamespace("vcr", quietly=TRUE)) {
+  reset_cached_files("ava")
+  reset_cached_files("deps")
+  reset_cached_files("desc")
 
-vcr::use_cassette("plot-1", {
-  deps <- deepdep("shiny", depth = 2)
-})
+  vcr::use_cassette("plot-1", {
+    deps <- deepdep("shiny", depth = 2)
+  })
 
-test_that("dependencies plot has correct layers and objects", {
-  plt <- plot_dependencies(deps)
-  expect_length(plt$layers, 4)
-  expect_s3_class(plt$layers[[1]]$geom, "GeomPath")
-  expect_s3_class(plt$layers[[1]]$stat, "StatIdentity")
-  expect_s3_class(plt$layers[[2]]$geom, "GeomEdgePath")
-  expect_s3_class(plt$layers[[2]]$stat, "StatEdgeLink")
-  expect_s3_class(plt$layers[[3]]$geom, "GeomPoint")
-  expect_s3_class(plt$layers[[3]]$stat, "StatFilter")
-  expect_s3_class(plt$layers[[4]]$geom, "GeomLabel")
-  expect_s3_class(plt$layers[[4]]$stat, "StatFilter")
-})
+
+  test_that("dependencies plot has correct layers and objects", {
+    plt <- plot_dependencies(deps)
+    expect_length(plt$layers, 4)
+    expect_s3_class(plt$layers[[1]]$geom, "GeomPath")
+    expect_s3_class(plt$layers[[1]]$stat, "StatIdentity")
+    expect_s3_class(plt$layers[[2]]$geom, "GeomEdgePath")
+    expect_s3_class(plt$layers[[2]]$stat, "StatEdgeLink")
+    expect_s3_class(plt$layers[[3]]$geom, "GeomPoint")
+    expect_s3_class(plt$layers[[3]]$stat, "StatFilter")
+    expect_s3_class(plt$layers[[4]]$geom, "GeomLabel")
+    expect_s3_class(plt$layers[[4]]$stat, "StatFilter")
+  })
+}
 
 test_that("incorrect object type results in an error", {
   expect_error(plot_dependencies("Wrong type"))
 })
 
-reset_cached_files("ava")
-reset_cached_files("deps")
-reset_cached_files("desc")
+if (requireNamespace("vcr", quietly=TRUE)) {
+  reset_cached_files("ava")
+  reset_cached_files("deps")
+  reset_cached_files("desc")
 
-vcr::use_cassette("plot-2", {
-  test_that("plotting deepdep object with no rows results in less layers", {
-    plt <- plot_dependencies("rlang")
-    expect_s3_class(plt$layers[[1]]$geom, "GeomPoint")
-    expect_s3_class(plt$layers[[1]]$stat, "StatFilter")
-    expect_s3_class(plt$layers[[2]]$geom, "GeomLabel")
-    expect_s3_class(plt$layers[[2]]$stat, "StatFilter")
+  vcr::use_cassette("plot-2", {
+    test_that("plotting deepdep object with no rows results in less layers", {
+      plt <- plot_dependencies("rlang")
+      expect_s3_class(plt$layers[[1]]$geom, "GeomPoint")
+      expect_s3_class(plt$layers[[1]]$stat, "StatFilter")
+      expect_s3_class(plt$layers[[2]]$geom, "GeomLabel")
+      expect_s3_class(plt$layers[[2]]$stat, "StatFilter")
 
+    })
   })
-})
+}


### PR DESCRIPTION
This is a slightly more 'risky' PR in the sense that I am not a regular user of `testthat` and certainly not of `vcr` which i don't even have installed -- so I cannot run `R CMD check` here for `deepdep` which is mildly irritating.  And, if we look closely at _Writing R Extensions_, incorrect.  Suggested packaged should be used _conditionally_ only.

This PR does that with minimal changes to the test files.  But again, from someone not using `testthat` so not sure if I broke some of the (many) (opinionated) rules here.  But it now tests for me, and is one step forward. 

Feel free to nudge and adjust by pushing to this branch, or close it if you wildly disagree.  The 'test only with Suggests: installed' issue does warrant some attention though (even if CRAN does not (yet?) enforce it it is slowly getting more attention).